### PR TITLE
Fix URLs in just 2023 things post

### DIFF
--- a/src/posts/blog/2023/2023-12-22-just-2024-things.md
+++ b/src/posts/blog/2023/2023-12-22-just-2024-things.md
@@ -72,7 +72,7 @@ I did not finish it yet. Maybe next year. The only book I read this year was the
 
 #### Podcasts
 
-The only new podcast I added to [my subscriptions](http://localhost:8080/podcasts/roll/) is [Hemispheric Views](https://hemisphericviews.com/). I enjoyed it so much I went back and [listened to all 78 episodes](http://localhost:8080/three-years-of-hemispheric-views-feedback/) over three months. Hemispheric Views was also how [App Defaults](https://defaults.rknight.me/) started, more about that below.
+The only new podcast I added to [my subscriptions](https://rknight.me/podcasts/roll/) is [Hemispheric Views](https://hemisphericviews.com/). I enjoyed it so much I went back and [listened to all 78 episodes](https://rknight.me/three-years-of-hemispheric-views-feedback/) over three months. Hemispheric Views was also how [App Defaults](https://defaults.rknight.me/) started, more about that below.
 ### Side Projects
 
 #### January: omg! lol!
@@ -115,4 +115,4 @@ _Photo courtesy of [Leon Mika](https://lmika.org/)_
 
 It's been a pretty good year all told. Now if I could find a way to get paid to make stupid web apps all day that'd be great.
 
-[^1]: I've excluded [these](https://rknight.me/convert-spotify-facebook-to-email-login/) [two](https://rknight.me//create-a-blank-no-header-markdown-table/) posts because although they are really popular they are very boring
+[^1]: I've excluded [these](https://rknight.me/convert-spotify-facebook-to-email-login/) [two](https://rknight.me/create-a-blank-no-header-markdown-table/) posts because although they are really popular they are very boring


### PR DESCRIPTION
I was reading through the archives and noticed a couple broken links. Cheers!

- a couple links pointed to localhost, which were updated to the production domain
- also removed an extra forward slash I spotted