### PR TITLE
Set dark theme for code snippets scrollbars

### DIFF
--- a/src/assets/css/_highlight.css
+++ b/src/assets/css/_highlight.css
@@ -47,6 +47,7 @@ pre[class*="language-"] {
 	position: relative;
 	margin: 0.5em 0;
 	padding: 1.25em 1em;
+	color-scheme: dark;
 }
 
 .language-css > code,


### PR DESCRIPTION
When scrollbars are always visible they use light theme by default. Enforcing dark theme make them look nicer in your design. 

Before:

<img width="1918" height="1954" alt="CleanShot 2026-01-06 at 18 14 35" src="https://github.com/user-attachments/assets/ead780bb-25c0-4f48-977c-c9935ea542e5" />

After:

<img width="1918" height="1954" alt="CleanShot 2026-01-06 at 18 14 23" src="https://github.com/user-attachments/assets/97367d9b-7c08-4f97-a0f4-d80cb901cfe6" />
